### PR TITLE
Update to a newer version of bindgen

### DIFF
--- a/v4l-sys/Cargo.toml
+++ b/v4l-sys/Cargo.toml
@@ -9,4 +9,4 @@ links = "v4l1 v4l2 4lconvert"
 build = "build.rs"
 
 [build-dependencies]
-bindgen = "0.53.2"
+bindgen = "0.55.1"

--- a/v4l2-sys/Cargo.toml
+++ b/v4l2-sys/Cargo.toml
@@ -8,4 +8,4 @@ license = "MIT"
 build = "build.rs"
 
 [build-dependencies]
-bindgen = "0.53.2"
+bindgen = "0.55.1"


### PR DESCRIPTION
The new version of bindgen depends on LLVM/Clang libs in a way that is incompatible with previous bindgen versions.  As a result, one cannot depend on two different crates that use bindgen if one of them uses an older bindgen version.