### PR TITLE
Fix compilation error against musl

### DIFF
--- a/src/v4l2/vidioc.rs
+++ b/src/v4l2/vidioc.rs
@@ -1,7 +1,11 @@
 use crate::v4l_sys::*;
 
+#[cfg(not(target_env = "musl"))]
 #[allow(non_camel_case_types)]
 pub type _IOC_TYPE = std::os::raw::c_ulong;
+#[cfg(target_env = "musl")]
+#[allow(non_camel_case_types)]
+pub type _IOC_TYPE = std::os::raw::c_long;
 
 // linux ioctl.h
 const _IOC_NRBITS: u8 = 8;


### PR DESCRIPTION
Musl seems to use an int rather than an unsigned int for the args to the `ioctl` function as glibc does. This results in a compilation error when building with for example, `target = armv7-unknown-linux-musleabihf`

This patch changes the type alias to the correct type on musl crates. I imagine this might also be a problem on other libc implementations, but I'll leave those as they are since I can't test them.