### PR TITLE
Fix example forward video

### DIFF
--- a/examples/forward_frame.rs
+++ b/examples/forward_frame.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 use v4l::buffer::Type;
 use v4l::io::traits::CaptureStream;
 use v4l::prelude::*;
-use v4l::video::Capture;
+use v4l::video::{Capture, Output};
 
 fn main() {
     let matches = App::new("v4l device")
@@ -54,10 +54,9 @@ fn main() {
     let mut output_dev = Device::with_path(output_path).expect("Failed to open output device");
 
     // Set the output's format to the same as the capture's
-    let format = capture_dev.format().unwrap();
-    output_dev
-        .set_format(&format)
-        .expect("Failed to set format of output device");
+    let format = Capture::format(&capture_dev).unwrap();
+
+    Output::set_format(&mut output_dev, &format).expect("Failed to set format for output device");
 
     // Setup a buffer stream, grab a frame, and write it to the output
     let mut stream = MmapStream::with_buffers(&capture_dev, Type::VideoCapture, 1)

--- a/examples/forward_video.rs
+++ b/examples/forward_video.rs
@@ -14,7 +14,7 @@ fn main() {
         .author("Nathan Varner <nathanmvarner@protonmail.com>")
         .about("Video4Linux device example")
         .arg(
-            Arg::with_name("capture_device")
+            Arg::with_name("capture-device")
                 .short("c")
                 .long("capture-device")
                 .value_name("INDEX or PATH")

--- a/examples/forward_video.rs
+++ b/examples/forward_video.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 use v4l::buffer::Type;
 use v4l::io::traits::CaptureStream;
 use v4l::prelude::*;
-use v4l::video::Capture;
+use v4l::video::{Capture, Output};
 
 fn main() {
     let matches = App::new("v4l device")
@@ -54,10 +54,9 @@ fn main() {
     let mut output_dev = Device::with_path(output_path).expect("Failed to open output device");
 
     // Set the output's format to the same as the capture's
-    let format = capture_dev.format().unwrap();
-    output_dev
-        .set_format(&format)
-        .expect("Failed to set format of output device");
+    let format = Capture::format(&capture_dev).unwrap();
+
+    Output::set_format(&mut output_dev, &format).expect("Failed to set format for output device");
 
     // Setup a buffer stream, grab a frame, and write it to the output
     let mut stream = MmapStream::with_buffers(&capture_dev, Type::VideoCapture, 1)


### PR DESCRIPTION
Hi!

These two examples didn't work for me using v4l2loopback. I figured out that this would work after looking at your `stream_forward_mmap.rs` example.

The error message I would get is:
```
thread 'main' panicked at 'Failed to set format of output device: Os { code: 16, kind: Other, message: "Device or resource busy" }', examples/forward_frame.rs:60:10
```

Incidentally, when I try the example from `stream_forward_mmap` it appears to work correctly, but if I try and play it with `ffplay` I'm not able to see anything.

I realise this example is quite new, should it be working?

(if it helps, the output I get after running stream_forward from running `ffplay /dev/video2`:
```
ffplay /dev/video2  
ffplay version n4.3.1 Copyright (c) 2003-2020 the FFmpeg developers
  built with gcc 10.2.0 (GCC)
  configuration: --prefix=/usr --disable-debug --disable-static --disable-stripping --enable-amf --enable-avisynth --enable-cuda-llvm --enable-lto --enable-fontconfig --enable-gmp --enable-gnutls --enable-gpl --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libdav1d --enable-libdrm --enable-libfreetype --enable-libfribidi --enable-libgsm --enable-libiec61883 --enable-libjack --enable-libmfx --enable-libmodplug --enable-libmp3lame --enable-libopencore_amrnb --enable-libopencore_amrwb --enable-libopenjpeg --enable-libopus --enable-libpulse --enable-librav1e --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --enable-libtheora --enable-libv4l2 --enable-libvidstab --enable-libvmaf --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxcb --enable-libxml2 --enable-libxvid --enable-nvdec --enable-nvenc --enable-shared --enable-version3
  libavutil      56. 51.100 / 56. 51.100
  libavcodec     58. 91.100 / 58. 91.100
  libavformat    58. 45.100 / 58. 45.100
  libavdevice    58. 10.100 / 58. 10.100
  libavfilter     7. 85.100 /  7. 85.100
  libswscale      5.  7.100 /  5.  7.100
  libswresample   3.  7.100 /  3.  7.100
  libpostproc    55.  7.100 / 55.  7.100
    nan    :  0.000 fd=   0 aq=    0KB vq=    0KB sq=    0B f=0/0   
```
and then hanging)