### PR TITLE
Enhance capture_device example with enum_frames, and add helper method.

### DIFF
--- a/examples/capture_device.rs
+++ b/examples/capture_device.rs
@@ -18,6 +18,12 @@ fn main() {
                 .help("Capture device node path or index (default: 0)")
                 .takes_value(true),
         )
+        .arg(
+            Arg::with_name("verbose")
+                .short("v")
+                .long("verbose")
+                .help("Whether to output verbose framesize and frameinterval information"),
+        )
         .get_matches();
 
     // Determine which device to use
@@ -34,5 +40,30 @@ fn main() {
     let format = dev.format().expect("Failed to get format");
     let params = dev.params().expect("Failed to get parameters");
     println!("Active format:\n{}", format);
+
+    if matches.is_present("verbose") {
+        for available_format in dev.enum_formats().expect("Failed to enumerate formats") {
+            println!("Available format:\n{}", available_format);
+            for available_framesize in dev
+                .enum_framesizes(available_format.fourcc)
+                .expect("Failed to enumerate framesizes")
+            {
+                println!("Available framesize:\n{}", available_framesize);
+                for available_discrete_framesize in available_framesize.size.discrete_framesizes() {
+                    for available_frameinterval in dev
+                        .enum_frameintervals(
+                            available_framesize.fourcc,
+                            available_discrete_framesize.width,
+                            available_discrete_framesize.height,
+                        )
+                        .expect("Failed to enumerate frameintervals")
+                    {
+                        println!("Available frameinterval:\n{}", available_frameinterval);
+                    }
+                }
+            }
+        }
+    }
+
     println!("Active parameters:\n{}", params);
 }

--- a/src/framesize.rs
+++ b/src/framesize.rs
@@ -5,7 +5,7 @@ use crate::format::FourCC;
 use crate::v4l_sys;
 use crate::v4l_sys::*;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Format description as returned by VIDIOC_ENUM_FRAMESIZES
 pub struct FrameSize {
     pub index: u32,
@@ -24,10 +24,37 @@ impl fmt::Display for FrameSize {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum FrameSizeEnum {
     Discrete(Discrete),
     Stepwise(Stepwise),
+}
+
+impl FrameSizeEnum {
+    pub fn discrete_framesizes(&self) -> Vec<Discrete> {
+        match self {
+            Self::Discrete(discrete) => {
+                vec![(*discrete).clone()]
+            }
+            Self::Stepwise(stepwise) => {
+                let mut return_vec = Vec::new();
+                for width in
+                    (stepwise.min_width..=stepwise.max_width).step_by(stepwise.step_width as usize)
+                {
+                    for height in (stepwise.min_height..=stepwise.max_height)
+                        .step_by(stepwise.step_height as usize)
+                    {
+                        let discrete = Discrete {
+                            width: width,
+                            height: height,
+                        };
+                        return_vec.push(discrete);
+                    }
+                }
+                return_vec
+            }
+        }
+    }
 }
 
 impl fmt::Display for FrameSizeEnum {
@@ -71,7 +98,7 @@ impl TryFrom<v4l2_frmsizeenum> for FrameSizeEnum {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Discrete {
     /// Width of the frame [pixel].
     pub width: u32,
@@ -86,7 +113,7 @@ impl fmt::Display for Discrete {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Stepwise {
     /// Minimum frame width [pixel].
     pub min_width: u32,


### PR DESCRIPTION
Hey, I didn't see an example on using the `enum_*` methods, and thought it could be handy.

I added it to an existing example, let me know if that's convenient or not. I also threw in a helper method in case people want to get a discrete vec of their stepwise resolutions (NOTE: I don't have a device with stepwise resolutions, so I technically haven't tested that one, but it's pretty straightforward).

Let me know what you think.