### PR TITLE
v4l2: api: Fix ioctl() argument type mismatch.

### DIFF
--- a/src/v4l2/api.rs
+++ b/src/v4l2/api.rs
@@ -52,7 +52,14 @@ mod detail {
         request: vidioc::_IOC_TYPE,
         argp: *mut std::os::raw::c_void,
     ) -> std::os::raw::c_int {
-        libc::ioctl(fd, request, argp)
+        /*
+         * It turns out the libc crate (and libc itself!) defines ioctl() with
+         * different, incompatible argument types on different platforms. To
+         * hack around this without conditional compilation, use syscall()
+         * instead as a drop-in replacement. Details:
+         * https://github.com/rust-lang/libc/issues/1036
+         */
+        libc::syscall(libc::SYS_ioctl, fd, request, argp) as std::os::raw::c_int
     }
     pub unsafe fn mmap(
         start: *mut std::os::raw::c_void,


### PR DESCRIPTION
Annoyingly, the libc crate defines ioctl()'s argument types differently
on different platforms. On x86_64-unknown-linux-gnu, the existing code
works just fine. But, on aarch64-unknown-linux-musl (and Android
apparently), the libc crate instead says it takes an int, so we get a
compilation error.

We could work around this by writing the code differently for different
targets with #[cfg()]. But, that's less than ideal.

So, hack around this by using syscall() instead. It's a variadic
function, so we can just pass ~whatever~ into it. We're kind of
depending on C's type conversion rules by doing so, but this turns out
to be kind of how e.g. glibc does it anyway.

At the end of the day: this should "just work" on all targets.

Signed-off-by: Axel Rasmussen <axelrasmussen@google.com>