### PR TITLE
Handover all buffers to v4l on stream start.

### DIFF
--- a/src/io/mmap/stream.rs
+++ b/src/io/mmap/stream.rs
@@ -166,10 +166,16 @@ impl<'a, 'b> CaptureStream<'b> for Stream<'a> {
 
     fn next(&'b mut self) -> io::Result<(&Self::Item, &Metadata)> {
         if !self.active {
+            // Enqueue all buffers once on stream start
+            for index in 0..self.arena.len() {
+                CaptureStream::queue(self, index)?;
+            }
+
             self.start()?;
+        } else {
+            CaptureStream::queue(self, self.arena_index)?;
         }
 
-        CaptureStream::queue(self, self.arena_index)?;
         self.arena_index = CaptureStream::dequeue(self)?;
 
         // The index used to access the buffer elements is given to us by v4l2, so we assume it

--- a/src/io/userptr/stream.rs
+++ b/src/io/userptr/stream.rs
@@ -169,10 +169,16 @@ impl<'a> CaptureStream<'a> for Stream {
 
     fn next(&'a mut self) -> io::Result<(&Self::Item, &Metadata)> {
         if !self.active {
+            // Enqueue all buffers once on stream start
+            for index in 0..self.arena.len() {
+                self.queue(index)?;
+            }
+
             self.start()?;
+        } else {
+            self.queue(self.arena_index)?;
         }
 
-        self.queue(self.arena_index)?;
         self.arena_index = self.dequeue()?;
 
         // The index used to access the buffer elements is given to us by v4l2, so we assume it

--- a/src/io/userptr/stream.rs
+++ b/src/io/userptr/stream.rs
@@ -85,11 +85,6 @@ impl StreamTrait for Stream {
     type Item = [u8];
 
     fn start(&mut self) -> io::Result<()> {
-        /* Give all buffers to v4l2 */
-        for index in 0..self.arena.len() {
-            self.queue(index)?;
-        }
-
         unsafe {
             let mut typ = self.buf_type as u32;
             v4l2::ioctl(
@@ -175,9 +170,9 @@ impl<'a> CaptureStream<'a> for Stream {
     fn next(&'a mut self) -> io::Result<(&Self::Item, &Metadata)> {
         if !self.active {
             self.start()?;
-        } else {
-            self.queue(self.arena_index)?;
         }
+
+        self.queue(self.arena_index)?;
         self.arena_index = self.dequeue()?;
 
         // The index used to access the buffer elements is given to us by v4l2, so we assume it


### PR DESCRIPTION
I had issues with my laptop not being able to capture as fast as I expected it would.
Even with the power setting on maximum performance it wasn't able to do 720p/30 MJPEG.

After some poking around I noticed that the user buffers weren't passed to v4l on initialization as you are supped to do.
Without enqueuing all unused buffers v4l have nowhere to store incoming frames until stream.next() is called which
enqueues one buffer.
This causes v4l to drop frames when stream.next() isn't called fast enough, i.e no time for any kind of processing of the images.

After this change my laptop have no  any issues capturing 720p/30 MJPEG, even in power saving mode.