### PR TITLE
Add support for ext ctrls

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -219,6 +219,11 @@ pub enum Value {
     Integer(i64),
     Boolean(bool),
     String(String),
+    /* compound (matrix) values */
+    CompoundU8(Vec<u8>),
+    CompoundU16(Vec<u16>),
+    CompoundU32(Vec<u32>),
+    CompoundPtr(Vec<u8>),
 }
 
 impl TryInto<v4l2_control> for Control {

--- a/src/control.rs
+++ b/src/control.rs
@@ -205,12 +205,19 @@ impl fmt::Display for Description {
 }
 
 #[derive(Debug)]
+pub struct Control {
+    pub id: u32,
+    pub value: Value,
+}
+
+#[derive(Debug)]
 /// Device control value
-pub enum Control {
+pub enum Value {
+    /* buttons */
+    None,
     /* single values */
     Integer(i64),
     Boolean(bool),
-    Button,
     String(String),
 }
 
@@ -220,16 +227,17 @@ impl TryInto<v4l2_control> for Control {
     fn try_into(self) -> Result<v4l2_control, Self::Error> {
         unsafe {
             let mut ctrl: v4l2_control = mem::zeroed();
-            match self {
-                Control::Integer(val) => {
+            ctrl.id = self.id;
+            match self.value {
+                Value::None => Ok(ctrl),
+                Value::Integer(val) => {
                     ctrl.value = val as i32;
                     Ok(ctrl)
                 }
-                Control::Boolean(val) => {
+                Value::Boolean(val) => {
                     ctrl.value = val as i32;
                     Ok(ctrl)
                 }
-                Control::Button => Ok(ctrl),
                 _ => Err(()),
             }
         }

--- a/src/control.rs
+++ b/src/control.rs
@@ -21,8 +21,7 @@ pub enum Type {
     IntegerMenu     = 9,
 
     /* Compound types are >= 0x0100 */
-    CompoundTypes   = 0x0100,
-    U8              = 0x1000,
+    U8              = 0x0100,
     U16             = 0x0101,
     U32             = 0x0102,
     Area            = 0x0106,

--- a/src/device.rs
+++ b/src/device.rs
@@ -268,6 +268,22 @@ impl Device {
                         control.__bindgen_anon_1.string = val.as_ptr() as *mut i8;
                         control.size = val.len() as u32;
                     }
+                    control::Value::CompoundU8(ref val) => {
+                        control.__bindgen_anon_1.p_u8 = val.as_ptr() as *mut u8;
+                        control.size = (val.len() * std::mem::size_of::<u8>()) as u32;
+                    }
+                    control::Value::CompoundU16(ref val) => {
+                        control.__bindgen_anon_1.p_u16 = val.as_ptr() as *mut u16;
+                        control.size = (val.len() * std::mem::size_of::<u16>()) as u32;
+                    }
+                    control::Value::CompoundU32(ref val) => {
+                        control.__bindgen_anon_1.p_u32 = val.as_ptr() as *mut u32;
+                        control.size = (val.len() * std::mem::size_of::<u32>()) as u32;
+                    }
+                    control::Value::CompoundPtr(ref val) => {
+                        control.__bindgen_anon_1.ptr = val.as_ptr() as *mut std::os::raw::c_void;
+                        control.size = (val.len() * std::mem::size_of::<u8>()) as u32;
+                    }
                 };
 
                 control_list.push(control);


### PR DESCRIPTION
This adds a basic Extended controls support. The v4l2 API provides a way to write arrays of data that are here passed as Vec<T>.