### PR TITLE
device: Cast string-pointer to c_char instead of i8

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -266,7 +266,7 @@ impl Device {
                         control.size = std::mem::size_of::<i64>() as u32;
                     }
                     control::Value::String(ref val) => {
-                        control.__bindgen_anon_1.string = val.as_ptr() as *mut i8;
+                        control.__bindgen_anon_1.string = val.as_ptr() as *mut std::os::raw::c_char;
                         control.size = val.len() as u32;
                     }
                     control::Value::CompoundU8(ref val) => {


### PR DESCRIPTION
On certain platforms, like when cross-compiling to Android, strings are defined as `u8` instead of `i8`.  The `c_char` type abstracts this detail away and is used in bindgen, and should hence be used in this cast too.
