### PR TITLE
cargo: Include -sys crates in workspace by fixing plural typo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default = ["v4l2"]
 libv4l = ["v4l-sys"]
 v4l2 = ["v4l2-sys"]
 
-[workspaces]
+[workspace]
 members = [
     "v4l-sys",
     "v4l2-sys",


### PR DESCRIPTION
The following warning shows while building:

    warning: unused manifest key: workspaces

The correct spelling is `[workspace]`, without s: https://doc.rust-lang.org/cargo/reference/workspaces.html#the-workspace-section
