### PR TITLE
Switch v4l2_ext_control string union cast to os::raw::c_char

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -266,7 +266,7 @@ impl Device {
                         control.size = std::mem::size_of::<i64>() as u32;
                     }
                     control::Value::String(ref val) => {
-                        control.__bindgen_anon_1.string = val.as_ptr() as *mut i8;
+                        control.__bindgen_anon_1.string = val.as_ptr() as *mut std::os::raw::c_char;
                         control.size = val.len() as u32;
                     }
                     control::Value::CompoundU8(ref val) => {


### PR DESCRIPTION
Switch v4l2_ext_control string union cast to os::raw::c_char instead of i8 to match type used by bindgen generated code

For some targets, like armv7-unknown-linux-gnueabihf, the os c_char type is u8
and casting to i8 resulting in the following compilation error:

```
error[E0308]: mismatched types
   --> src/device.rs:269:59
    |
269 |                         control.__bindgen_anon_1.string = val.as_ptr() as *mut i8;
    |                                                           ^^^^^^^^^^^^^^^^^^^^^^^ expected `u8`, found `i8`
    |
    = note: expected raw pointer `*mut u8`
               found raw pointer `*mut i8`
```
