### PR TITLE
api: Update doc link for request codes.

### DIFF
--- a/src/v4l2/api.rs
+++ b/src/v4l2/api.rs
@@ -153,7 +153,7 @@ pub fn close(fd: std::os::raw::c_int) -> io::Result<()> {
 /// * `request` - IO control code (see [codes])
 /// * `argp` - Pointer to memory region holding the argument type
 ///
-/// [codes]: v4l::ioctl::codes
+/// [codes]: v4l::v4l2::vidioc
 ///
 /// # Safety
 ///


### PR DESCRIPTION
I'm not sure if this is the right link, but the current link is broken as seen on https://docs.rs/v4l/latest/v4l/v4l2/api/fn.ioctl.html