### PR TITLE
Don't block when unplugging camera

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -40,11 +40,8 @@ impl Device {
             return Err(io::Error::last_os_error());
         }
 
-        let mut fd_set = FdSet::new();
-        fd_set.set(fd);
-
         Ok(Device {
-            handle: Arc::new(Handle { fd, fd_set }),
+            handle: Arc::new(Handle::new(fd)),
         })
     }
 
@@ -69,11 +66,8 @@ impl Device {
             return Err(io::Error::last_os_error());
         }
 
-        let mut fd_set = FdSet::new();
-        fd_set.set(fd);
-
         Ok(Device {
-            handle: Arc::new(Handle { fd, fd_set }),
+            handle: Arc::new(Handle::new(fd)),
         })
     }
 
@@ -379,6 +373,13 @@ pub struct Handle {
 }
 
 impl Handle {
+    fn new(fd: std::os::raw::c_int) -> Self {
+        let mut fd_set = FdSet::new();
+        fd_set.set(fd);
+
+        Self { fd, fd_set }
+    }
+
     /// Returns the raw file descriptor
     pub fn fd(&self) -> std::os::raw::c_int {
         self.fd

--- a/src/device.rs
+++ b/src/device.rs
@@ -374,7 +374,7 @@ pub struct Handle {
 
 impl Handle {
     fn new(fd: std::os::raw::c_int) -> Self {
-        let mut fd_set = FdSet::new();
+        let mut fd_set = FdSet::default();
         fd_set.set(fd);
 
         Self { fd, fd_set }

--- a/src/device.rs
+++ b/src/device.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::{io, mem};
 
 use crate::control;
+use crate::pselect::FdSet;
 use crate::v4l2;
 use crate::v4l2::videodev::v4l2_ext_controls;
 use crate::v4l_sys::*;
@@ -33,14 +34,17 @@ impl Device {
     /// ```
     pub fn new(index: usize) -> io::Result<Self> {
         let path = format!("{}{}", "/dev/video", index);
-        let fd = v4l2::open(&path, libc::O_RDWR)?;
+        let fd = v4l2::open(&path, libc::O_RDWR | libc::O_NONBLOCK)?;
 
         if fd == -1 {
             return Err(io::Error::last_os_error());
         }
 
+        let mut fd_set = FdSet::new();
+        fd_set.set(fd);
+
         Ok(Device {
-            handle: Arc::new(Handle { fd }),
+            handle: Arc::new(Handle { fd, fd_set }),
         })
     }
 
@@ -59,14 +63,17 @@ impl Device {
     /// let dev = Device::with_path("/dev/video0");
     /// ```
     pub fn with_path<P: AsRef<Path>>(path: P) -> io::Result<Self> {
-        let fd = v4l2::open(&path, libc::O_RDWR)?;
+        let fd = v4l2::open(&path, libc::O_RDWR | libc::O_NONBLOCK)?;
 
         if fd == -1 {
             return Err(io::Error::last_os_error());
         }
 
+        let mut fd_set = FdSet::new();
+        fd_set.set(fd);
+
         Ok(Device {
-            handle: Arc::new(Handle { fd }),
+            handle: Arc::new(Handle { fd, fd_set }),
         })
     }
 
@@ -368,12 +375,18 @@ impl io::Write for Device {
 /// Acquiring a handle facilitates (possibly mutating) interactions with the device.
 pub struct Handle {
     fd: std::os::raw::c_int,
+    fd_set: FdSet,
 }
 
 impl Handle {
     /// Returns the raw file descriptor
     pub fn fd(&self) -> std::os::raw::c_int {
         self.fd
+    }
+
+    /// Returns the raw file descriptor set
+    pub fn fd_set(&self) -> FdSet {
+        self.fd_set
     }
 }
 

--- a/src/io/mmap/stream.rs
+++ b/src/io/mmap/stream.rs
@@ -128,15 +128,6 @@ impl<'a, 'b> CaptureStream<'b> for Stream<'a> {
             ..self.buffer_desc()
         };
 
-        pselect(
-            self.handle.fd() + 1,
-            Some(&mut self.handle.fd_set()),
-            None,
-            None,
-            None,
-            None,
-        )?;
-
         unsafe {
             v4l2::ioctl(
                 self.handle.fd(),

--- a/src/io/userptr/stream.rs
+++ b/src/io/userptr/stream.rs
@@ -5,6 +5,7 @@ use crate::device::{Device, Handle};
 use crate::io::traits::{CaptureStream, Stream as StreamTrait};
 use crate::io::userptr::arena::Arena;
 use crate::memory::Memory;
+use crate::pselect::pselect;
 use crate::v4l2;
 use crate::v4l_sys::*;
 
@@ -144,6 +145,16 @@ impl<'a> CaptureStream<'a> for Stream {
 
     fn dequeue(&mut self) -> io::Result<usize> {
         let mut v4l2_buf = self.buffer_desc();
+
+        pselect(
+            self.handle.fd() + 1,
+            Some(&mut self.handle.fd_set()),
+            None,
+            None,
+            None,
+            None,
+        )?;
+
         unsafe {
             v4l2::ioctl(
                 self.handle.fd(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,7 @@ pub mod timestamp;
 pub mod video;
 
 pub mod io;
+mod pselect;
 
 pub use {
     capability::Capabilities,

--- a/src/pselect.rs
+++ b/src/pselect.rs
@@ -1,0 +1,64 @@
+use std::os::unix::io::RawFd;
+use std::{io, mem, ptr, time};
+
+#[derive(Clone, Copy)]
+pub struct FdSet(libc::fd_set);
+
+impl FdSet {
+    pub fn new() -> FdSet {
+        unsafe {
+            let mut raw_fd_set = mem::MaybeUninit::<libc::fd_set>::uninit();
+            libc::FD_ZERO(raw_fd_set.as_mut_ptr());
+            FdSet(raw_fd_set.assume_init())
+        }
+    }
+
+    pub fn set(&mut self, fd: RawFd) {
+        unsafe {
+            libc::FD_SET(fd, &mut self.0);
+        }
+    }
+}
+
+fn to_fdset_ptr(opt: Option<&mut FdSet>) -> *mut libc::fd_set {
+    match opt {
+        None => ptr::null_mut(),
+        Some(&mut FdSet(ref mut raw_fd_set)) => raw_fd_set,
+    }
+}
+fn to_ptr<T>(opt: Option<&T>) -> *const T {
+    match opt {
+        None => ptr::null::<T>(),
+        Some(p) => p,
+    }
+}
+
+pub fn pselect(
+    nfds: libc::c_int,
+    readfds: Option<&mut FdSet>,
+    writefds: Option<&mut FdSet>,
+    errorfds: Option<&mut FdSet>,
+    timeout: Option<&libc::timespec>,
+    sigmask: Option<&libc::sigset_t>,
+) -> io::Result<usize> {
+    match unsafe {
+        libc::pselect(
+            nfds,
+            to_fdset_ptr(readfds),
+            to_fdset_ptr(writefds),
+            to_fdset_ptr(errorfds),
+            to_ptr(timeout),
+            to_ptr(sigmask),
+        )
+    } {
+        -1 => Err(io::Error::last_os_error()),
+        res => Ok(res as usize),
+    }
+}
+
+pub fn make_timespec(duration: time::Duration) -> libc::timespec {
+    libc::timespec {
+        tv_sec: duration.as_secs() as i64,
+        tv_nsec: duration.subsec_nanos() as i64,
+    }
+}

--- a/src/pselect.rs
+++ b/src/pselect.rs
@@ -60,7 +60,7 @@ pub fn pselect(
 
 pub fn make_timespec(duration: time::Duration) -> libc::timespec {
     libc::timespec {
-        tv_sec: duration.as_secs() as i64,
-        tv_nsec: duration.subsec_nanos() as i64,
+        tv_sec: duration.as_secs() as _,
+        tv_nsec: duration.subsec_nanos() as _,
     }
 }

--- a/src/pselect.rs
+++ b/src/pselect.rs
@@ -4,15 +4,17 @@ use std::{io, mem, ptr, time};
 #[derive(Clone, Copy)]
 pub struct FdSet(libc::fd_set);
 
-impl FdSet {
-    pub fn new() -> FdSet {
+impl Default for FdSet {
+    fn default() -> Self {
         unsafe {
             let mut raw_fd_set = mem::MaybeUninit::<libc::fd_set>::uninit();
             libc::FD_ZERO(raw_fd_set.as_mut_ptr());
             FdSet(raw_fd_set.assume_init())
         }
     }
+}
 
+impl FdSet {
     pub fn set(&mut self, fd: RawFd) {
         unsafe {
             libc::FD_SET(fd, &mut self.0);


### PR DESCRIPTION
This resolves #16.

Additionally, are you interested in supporting a `timeout` for polling the frames? Using `pselect` this is doable now.