### PR TITLE
Build-test documentation in Travis and fix intradoc links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,10 @@ jobs:
         - rustup component add clippy
       script:
         - cargo clippy -- -D warnings
+    - stage: Build-test docs
+      env: RUSTDOCFLAGS=-Dwarnings
+      script:
+        - cargo doc --no-deps --workspace --document-private-items
 
 stages:
   - check

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -114,7 +114,7 @@ impl fmt::Display for Capabilities {
             "Version     : {}.{}.{}",
             self.version.0, self.version.1, self.version.2
         )?;
-        writeln!(f, "Capabilites : {}", self.capabilities)?;
+        writeln!(f, "Capabilities : {}", self.capabilities)?;
         Ok(())
     }
 }

--- a/src/format/description.rs
+++ b/src/format/description.rs
@@ -33,7 +33,7 @@ impl fmt::Display for Flags {
 }
 
 #[derive(Debug)]
-/// Format description as returned by VIDIOC_ENUM_FMT
+/// Format description as returned by [`crate::v4l2::vidioc::VIDIOC_ENUM_FMT`]
 pub struct Description {
     pub index: u32,
     pub typ: u32,

--- a/src/frameinterval.rs
+++ b/src/frameinterval.rs
@@ -5,7 +5,7 @@ use crate::{format::FourCC, fraction::Fraction};
 use crate::{v4l_sys, v4l_sys::*};
 
 #[derive(Debug)]
-/// Format description as returned by VIDIOC_ENUM_FRAMEINTERVALS
+/// Format description as returned by [`crate::v4l2::vidioc::VIDIOC_ENUM_FRAMEINTERVALS`]
 pub struct FrameInterval {
     pub index: u32,
     pub fourcc: FourCC,
@@ -64,11 +64,11 @@ impl TryFrom<v4l2_frmivalenum> for FrameIntervalEnum {
 
 #[derive(Debug)]
 pub struct Stepwise {
-    /// Minimum frame interval [s].
+    /// Minimum frame interval (in seconds).
     pub min: Fraction,
-    /// Maximum frame interval [s].
+    /// Maximum frame interval (in seconds).
     pub max: Fraction,
-    /// Frame interval step size [s].
+    /// Frame interval step size (in seconds).
     pub step: Fraction,
 }
 

--- a/src/framesize.rs
+++ b/src/framesize.rs
@@ -6,7 +6,7 @@ use crate::v4l_sys;
 use crate::v4l_sys::*;
 
 #[derive(Debug)]
-/// Format description as returned by VIDIOC_ENUM_FRAMESIZES
+/// Format description as returned by [`crate::v4l2::vidioc::VIDIOC_ENUM_FRAMESIZES`]
 pub struct FrameSize {
     pub index: u32,
     pub fourcc: FourCC,
@@ -95,9 +95,9 @@ impl TryFrom<v4l2_frmsizeenum> for FrameSizeEnum {
 
 #[derive(Debug)]
 pub struct Discrete {
-    /// Width of the frame [pixel].
+    /// Width of the frame (in pixels).
     pub width: u32,
-    /// Height of the frame [pixel].
+    /// Height of the frame (in pixels).
     pub height: u32,
 }
 
@@ -110,17 +110,17 @@ impl fmt::Display for Discrete {
 
 #[derive(Debug)]
 pub struct Stepwise {
-    /// Minimum frame width [pixel].
+    /// Minimum frame width (in pixels).
     pub min_width: u32,
-    /// Maximum frame width [pixel].
+    /// Maximum frame width (in pixels).
     pub max_width: u32,
-    /// Frame width step size [pixel].
+    /// Frame width step size (in pixels).
     pub step_width: u32,
-    /// Minimum frame height [pixel].
+    /// Minimum frame height (in pixels).
     pub min_height: u32,
-    /// Maximum frame height [pixel].
+    /// Maximum frame height (in pixels).
     pub max_height: u32,
-    /// Frame height step size [pixel].
+    /// Frame height step size (in pixels).
     pub step_height: u32,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,20 +16,20 @@
 //! e.g. "/dev/video0" for the device which first became known to the system.
 //!
 //! There are three methods of dealing with (capture) device memory:
-//! * MMAP (memory region in device memory or kernel space, mapped into userspace)
-//! * User pointer (memory region allocated in host memory, written into by the kernel)
-//! * DMA (direct memory access for memory transfer without involving the CPU)
+//! * `MMAP` (memory region in device memory or kernel space, mapped into userspace)
+//! * `User` pointer (memory region allocated in host memory, written into by the kernel)
+//! * `DMA` (direct memory access for memory transfer without involving the CPU)
 //!
-//! The following schematic shows the mmap and userptr mechanisms:
+//! The following schematic shows the `mmap` and `userptr` mechanisms:
 //!
 //! **mmap**
 //!
-//! 1. device --[MAP]--> kernel --[MAP]--> user
-//! 2. device --[DMA]--> kernel --[MAP]--> user
+//! 1. `device --[MAP]--> kernel --[MAP]--> user`
+//! 2. `device --[DMA]--> kernel --[MAP]--> user`
 //!
 //! **userptr**
 //!
-//! 3. device --[DMA]-->                   user
+//! 3. `device --[DMA]-->                   user`
 //!
 //!
 //! It is important to note that user pointer is for device-to-user memory transfer whereas
@@ -39,7 +39,7 @@
 //! As you can see, user pointer and DMA are potential candidates for zero-copy applications where
 //! buffers should be writable. If a read-only buffer is good enough, MMAP buffers are fine and
 //! do not incur any copy overhead either. Most (if not all) devices reporting streaming I/O
-//! capabilites support MMAP buffer sharing, but not all support user pointer access.
+//! capabilities support MMAP buffer sharing, but not all support user pointer access.
 //!
 //! The regular user of this crate will mainly be interested in frame capturing.
 //! Here is a very brief example of streaming I/O with memory mapped buffers:

--- a/src/v4l2/api.rs
+++ b/src/v4l2/api.rs
@@ -150,10 +150,8 @@ pub fn close(fd: std::os::raw::c_int) -> io::Result<()> {
 /// # Arguments
 ///
 /// * `fd` - File descriptor
-/// * `request` - IO control code (see [codes])
+/// * `request` - IO control code (see [`vidioc`])
 /// * `argp` - Pointer to memory region holding the argument type
-///
-/// [codes]: v4l::ioctl::codes
 ///
 /// # Safety
 ///


### PR DESCRIPTION
Fix the broken intra-doc link to ioctl codes, and remove all units between brackets which are treated as links in markdown.  The CI now build-tests the documentation to prevent broken links and other issues in the future.  Aside that, improve the markdown style and fix a typo.

CC #47
