### PR TITLE
Fix wrong _IOC_TYPE on musl

### DIFF
--- a/src/v4l2/vidioc.rs
+++ b/src/v4l2/vidioc.rs
@@ -1,11 +1,7 @@
 use crate::v4l_sys::*;
 
-#[cfg(not(target_env = "musl"))]
 #[allow(non_camel_case_types)]
 pub type _IOC_TYPE = std::os::raw::c_ulong;
-#[cfg(target_env = "musl")]
-#[allow(non_camel_case_types)]
-pub type _IOC_TYPE = std::os::raw::c_long;
 
 // linux ioctl.h
 const _IOC_NRBITS: u8 = 8;


### PR DESCRIPTION
When compiling on Alpine Linux x86_64 with Alpine's rust and target `x86_64-alpine-linux-musl`:

    error[E0308]: mismatched types
      --> libv4l-rs-917e1f4ffd90b94a/d7ac716/src/v4l2/api.rs:23:24
       |
    23 |         v4l2_ioctl(fd, request, argp)
       |                        ^^^^^^^ expected `u64`, found `i64`

Ref maximbaz/wluma#43