### PR TITLE
device: Use ctrls instead of ctrl structure in VIDIOC_G_EXT_CTRLS

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -191,7 +191,7 @@ impl Device {
             v4l2::ioctl(
                 self.handle().fd(),
                 v4l2::vidioc::VIDIOC_G_EXT_CTRLS,
-                &mut v4l2_ctrl as *mut _ as *mut std::os::raw::c_void,
+                &mut v4l2_ctrls as *mut _ as *mut std::os::raw::c_void,
             )?;
 
             let value = match description.typ {


### PR DESCRIPTION
The v4l2_ctrls struct was unused (found after converting the assignments to a struct initializer, expect a bigger PR for that later), and v4l2_ctrl was erroneously passed as pointer argument to VIDIOC_G_EXT_CTRLS.

Also use the newer style of `.cast()` to perform raw pointer casts with coercion, to appease rusts (currently default-allowed, though) `trivial_casts` lint.

Fixes: 99ebd12 ("control: Complete transition to VIDIOC_{G,S}_EXT_CTRLS API (#41)")
