### PR TITLE
Use struct initializers instead of member initializers over zeroed data

### DIFF
--- a/src/control.rs
+++ b/src/control.rs
@@ -231,8 +231,10 @@ impl TryInto<v4l2_control> for Control {
 
     fn try_into(self) -> Result<v4l2_control, Self::Error> {
         unsafe {
-            let mut ctrl: v4l2_control = mem::zeroed();
-            ctrl.id = self.id;
+            let mut ctrl = v4l2_control {
+                id: self.id,
+                ..mem::zeroed()
+            };
             match self.value {
                 Value::None => Ok(ctrl),
                 Value::Integer(val) => {

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -139,21 +139,18 @@ impl From<v4l2_pix_format> for Format {
 
 impl Into<v4l2_pix_format> for Format {
     fn into(self: Format) -> v4l2_pix_format {
-        let mut fmt: v4l2_pix_format;
-        unsafe {
-            fmt = mem::zeroed();
+        v4l2_pix_format {
+            width: self.width,
+            height: self.height,
+            pixelformat: self.fourcc.into(),
+            field: self.field_order as u32,
+            bytesperline: self.stride,
+            sizeimage: self.size,
+            colorspace: self.colorspace as u32,
+            flags: self.flags.into(),
+            quantization: self.quantization as u32,
+            xfer_func: self.transfer as u32,
+            ..unsafe { mem::zeroed() }
         }
-
-        fmt.width = self.width;
-        fmt.height = self.height;
-        fmt.pixelformat = self.fourcc.into();
-        fmt.field = self.field_order as u32;
-        fmt.bytesperline = self.stride;
-        fmt.sizeimage = self.size;
-        fmt.colorspace = self.colorspace as u32;
-        fmt.flags = self.flags.into();
-        fmt.quantization = self.quantization as u32;
-        fmt.xfer_func = self.transfer as u32;
-        fmt
     }
 }

--- a/src/fraction.rs
+++ b/src/fraction.rs
@@ -1,5 +1,5 @@
 use crate::v4l_sys::*;
-use std::{fmt, mem};
+use std::fmt;
 
 #[derive(Debug, Default, Clone, Copy)]
 /// Fraction used for timing settings
@@ -47,13 +47,9 @@ impl From<v4l2_fract> for Fraction {
 
 impl Into<v4l2_fract> for Fraction {
     fn into(self: Fraction) -> v4l2_fract {
-        let mut frac: v4l2_fract;
-        unsafe {
-            frac = mem::zeroed();
+        v4l2_fract {
+            numerator: self.numerator,
+            denominator: self.denominator,
         }
-
-        frac.numerator = self.numerator;
-        frac.denominator = self.denominator;
-        frac
     }
 }

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1,4 +1,4 @@
-use std::{fmt, mem, time};
+use std::{fmt, time};
 
 use crate::v4l_sys::*;
 
@@ -45,15 +45,11 @@ impl From<timeval> for Timestamp {
 }
 
 impl Into<timeval> for Timestamp {
-    fn into(self: Timestamp) -> timeval {
-        let mut tv: timeval;
-        unsafe {
-            tv = mem::zeroed();
+    fn into(self) -> timeval {
+        timeval {
+            tv_sec: self.sec as time_t,
+            tv_usec: self.usec as time_t,
         }
-
-        tv.tv_sec = self.sec as time_t;
-        tv.tv_usec = self.usec as time_t;
-        tv
     }
 }
 

--- a/src/video/capture/mod.rs
+++ b/src/video/capture/mod.rs
@@ -23,8 +23,10 @@ impl Capture for Device {
 
     fn params(&self) -> io::Result<Parameters> {
         unsafe {
-            let mut v4l2_params: v4l2_streamparm = mem::zeroed();
-            v4l2_params.type_ = Type::VideoCapture as u32;
+            let mut v4l2_params = v4l2_streamparm {
+                type_: Type::VideoCapture as u32,
+                ..mem::zeroed()
+            };
             v4l2::ioctl(
                 self.handle().fd(),
                 v4l2::vidioc::VIDIOC_G_PARM,
@@ -37,9 +39,12 @@ impl Capture for Device {
 
     fn set_params(&self, params: &Parameters) -> io::Result<Parameters> {
         unsafe {
-            let mut v4l2_params: v4l2_streamparm = mem::zeroed();
-            v4l2_params.type_ = Type::VideoCapture as u32;
-            v4l2_params.parm.capture = (*params).into();
+            let mut v4l2_params = v4l2_streamparm {
+                type_: Type::VideoCapture as u32,
+                parm: v4l2_streamparm__bindgen_ty_1 {
+                    capture: (*params).into(),
+                },
+            };
             v4l2::ioctl(
                 self.handle().fd(),
                 v4l2::vidioc::VIDIOC_S_PARM,

--- a/src/video/capture/parameters.rs
+++ b/src/video/capture/parameters.rs
@@ -76,14 +76,11 @@ impl From<v4l2_captureparm> for Parameters {
 
 impl Into<v4l2_captureparm> for Parameters {
     fn into(self: Parameters) -> v4l2_captureparm {
-        let mut params: v4l2_captureparm;
-        unsafe {
-            params = mem::zeroed();
+        v4l2_captureparm {
+            capability: self.capabilities.into(),
+            capturemode: self.modes.into(),
+            timeperframe: self.interval.into(),
+            ..unsafe { mem::zeroed() }
         }
-
-        params.capability = self.capabilities.into();
-        params.capturemode = self.modes.into();
-        params.timeperframe = self.interval.into();
-        params
     }
 }

--- a/src/video/macros.rs
+++ b/src/video/macros.rs
@@ -7,12 +7,13 @@ macro_rules! impl_enum_frameintervals {
             height: u32,
         ) -> io::Result<Vec<FrameInterval>> {
             let mut frameintervals = Vec::new();
-            let mut v4l2_struct: v4l2_frmivalenum = unsafe { mem::zeroed() };
-
-            v4l2_struct.index = 0;
-            v4l2_struct.pixel_format = fourcc.into();
-            v4l2_struct.width = width;
-            v4l2_struct.height = height;
+            let mut v4l2_struct = v4l2_frmivalenum {
+                index: 0,
+                pixel_format: fourcc.into(),
+                width,
+                height,
+                ..unsafe { mem::zeroed() }
+            };
 
             loop {
                 let ret = unsafe {
@@ -45,10 +46,11 @@ macro_rules! impl_enum_framesizes {
     () => {
         fn enum_framesizes(&self, fourcc: FourCC) -> io::Result<Vec<FrameSize>> {
             let mut framesizes = Vec::new();
-            let mut v4l2_struct: v4l2_frmsizeenum = unsafe { mem::zeroed() };
-
-            v4l2_struct.index = 0;
-            v4l2_struct.pixel_format = fourcc.into();
+            let mut v4l2_struct = v4l2_frmsizeenum {
+                index: 0,
+                pixel_format: fourcc.into(),
+                ..unsafe { mem::zeroed() }
+            };
 
             loop {
                 let ret = unsafe {
@@ -81,14 +83,11 @@ macro_rules! impl_enum_formats {
     ($typ:expr) => {
         fn enum_formats(&self) -> io::Result<Vec<FormatDescription>> {
             let mut formats: Vec<FormatDescription> = Vec::new();
-            let mut v4l2_fmt: v4l2_fmtdesc;
-
-            unsafe {
-                v4l2_fmt = mem::zeroed();
-            }
-
-            v4l2_fmt.index = 0;
-            v4l2_fmt.type_ = $typ as u32;
+            let mut v4l2_fmt = v4l2_fmtdesc {
+                index: 0,
+                type_: $typ as u32,
+                ..unsafe { mem::zeroed() }
+            };
 
             let mut ret: io::Result<()>;
 
@@ -132,8 +131,10 @@ macro_rules! impl_format {
     ($typ:expr) => {
         fn format(&self) -> io::Result<Format> {
             unsafe {
-                let mut v4l2_fmt: v4l2_format = mem::zeroed();
-                v4l2_fmt.type_ = $typ as u32;
+                let mut v4l2_fmt = v4l2_format {
+                    type_: $typ as u32,
+                    ..mem::zeroed()
+                };
                 v4l2::ioctl(
                     self.handle().fd(),
                     v4l2::vidioc::VIDIOC_G_FMT,
@@ -150,9 +151,10 @@ macro_rules! impl_set_format {
     ($typ:expr) => {
         fn set_format(&self, fmt: &Format) -> io::Result<Format> {
             unsafe {
-                let mut v4l2_fmt: v4l2_format = mem::zeroed();
-                v4l2_fmt.type_ = $typ as u32;
-                v4l2_fmt.fmt.pix = (*fmt).into();
+                let mut v4l2_fmt = v4l2_format {
+                    type_: $typ as u32,
+                    fmt: v4l2_format__bindgen_ty_1 { pix: (*fmt).into() },
+                };
                 v4l2::ioctl(
                     self.handle().fd(),
                     v4l2::vidioc::VIDIOC_S_FMT,

--- a/src/video/output/mod.rs
+++ b/src/video/output/mod.rs
@@ -23,8 +23,10 @@ impl Output for Device {
 
     fn params(&self) -> io::Result<Parameters> {
         unsafe {
-            let mut v4l2_params: v4l2_streamparm = mem::zeroed();
-            v4l2_params.type_ = Type::VideoOutput as u32;
+            let mut v4l2_params = v4l2_streamparm {
+                type_: Type::VideoOutput as u32,
+                ..mem::zeroed()
+            };
             v4l2::ioctl(
                 self.handle().fd(),
                 v4l2::vidioc::VIDIOC_G_PARM,
@@ -37,9 +39,12 @@ impl Output for Device {
 
     fn set_params(&self, params: &Parameters) -> io::Result<Parameters> {
         unsafe {
-            let mut v4l2_params: v4l2_streamparm = mem::zeroed();
-            v4l2_params.type_ = Type::VideoOutput as u32;
-            v4l2_params.parm.output = (*params).into();
+            let mut v4l2_params = v4l2_streamparm {
+                type_: Type::VideoOutput as u32,
+                parm: v4l2_streamparm__bindgen_ty_1 {
+                    output: (*params).into(),
+                },
+            };
             v4l2::ioctl(
                 self.handle().fd(),
                 v4l2::vidioc::VIDIOC_S_PARM,

--- a/src/video/output/parameters.rs
+++ b/src/video/output/parameters.rs
@@ -46,13 +46,10 @@ impl From<v4l2_outputparm> for Parameters {
 
 impl Into<v4l2_outputparm> for Parameters {
     fn into(self: Parameters) -> v4l2_outputparm {
-        let mut params: v4l2_outputparm;
-        unsafe {
-            params = mem::zeroed();
+        v4l2_outputparm {
+            capability: self.capabilities.into(),
+            timeperframe: self.interval.into(),
+            ..unsafe { mem::zeroed() }
         }
-
-        params.capability = self.capabilities.into();
-        params.timeperframe = self.interval.into();
-        params
     }
 }


### PR DESCRIPTION
The main advantages are:

- More readable as the variable name of the struct need not be repeated;
- `mem::zeroed()` can be dropped (there is a lint for this) if all members are initialized;
- Sometimes `mut` can be dropped, as no variables are updated anymore after initialization;
- Helped the linter uncover an "unused variable" that turned out to be a bug (wrong local variable was used: #52), which it is strangely not able to find for mutable structs that are only ever initialized and updated, but never read.

Downsides:
- Some apparently find the syntax "ugly", in particular around FFI contexts?
- Depending on the context, takes 1-2 more lines of code;
- This PR contains some semantic changes where a simple field update of ie. `.index` is replaced with a re-initialization of the entire struct. That should probably be undone.

Disclaimer: I wrote these changes some time ago, and haven't revisited the entire diff to make sure everything is correct. Self-review pending... :)
