### PR TITLE
Run `cargo clippy --fix` on Rust 1.63

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -73,7 +73,7 @@ impl Node {
 
         let mut index_str = String::new();
         for c in file_name.to_str().unwrap().chars() {
-            if !c.is_digit(10) {
+            if !c.is_ascii_digit() {
                 continue;
             }
 

--- a/src/control.rs
+++ b/src/control.rs
@@ -8,7 +8,7 @@ use crate::v4l_sys::*;
 #[allow(clippy::unreadable_literal)]
 #[rustfmt::skip]
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Type {
     Integer         = 1,
     Boolean         = 2,


### PR DESCRIPTION
Address some new linter warnings through cleanup, that are preventing other PRs from making it in.
