### PR TITLE
controls: i32 separate handling

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -35,7 +35,7 @@ impl Device {
     /// ```
     pub fn new(index: usize) -> io::Result<Self> {
         let path = format!("{}{}", "/dev/video", index);
-        let fd = v4l2::open(&path, libc::O_RDWR | libc::O_NONBLOCK)?;
+        let fd = v4l2::open(path, libc::O_RDWR | libc::O_NONBLOCK)?;
 
         if fd == -1 {
             return Err(io::Error::last_os_error());
@@ -204,11 +204,14 @@ impl Device {
             )?;
 
             let value = match description.typ {
-                control::Type::Integer | control::Type::Integer64 | control::Type::Menu => {
+                control::Type::Integer64 => {
                     control::Value::Integer(v4l2_ctrl.__bindgen_anon_1.value64)
                 }
+                control::Type::Integer | control::Type::Menu => {
+                    control::Value::Integer(v4l2_ctrl.__bindgen_anon_1.value as i64)
+                }
                 control::Type::Boolean => {
-                    control::Value::Boolean(v4l2_ctrl.__bindgen_anon_1.value64 == 1)
+                    control::Value::Boolean(v4l2_ctrl.__bindgen_anon_1.value == 1)
                 }
                 _ => {
                     return Err(io::Error::new(


### PR DESCRIPTION
I had a issue while parsing for a value presented as i32 instead of i64. 
(basically one of my laptop's camera brightness goes from -64 to 64 and that caused a panic anytime I'd set it to a negative number)
Should every case be handled differently?  for now, just adjusted it for my own needs.
PS: thanks a lot for the library! =)