### PR TITLE
Fixed wrong size field in VIDIOC_S_EXT_CTRLS ioctl

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -274,11 +274,11 @@ impl Device {
                     control::Value::None => {}
                     control::Value::Integer(val) => {
                         control.__bindgen_anon_1.value64 = val;
-                        control.size = std::mem::size_of::<i64>() as u32;
+                        control.size = 0;
                     }
                     control::Value::Boolean(val) => {
                         control.__bindgen_anon_1.value64 = val as i64;
-                        control.size = std::mem::size_of::<i64>() as u32;
+                        control.size = 0;
                     }
                     control::Value::String(ref val) => {
                         control.__bindgen_anon_1.string = val.as_ptr() as *mut std::os::raw::c_char;


### PR DESCRIPTION
As per https://www.kernel.org/doc/html/v4.9/media/uapi/v4l/vidioc-g-ext-ctrls.html info, the __u32 size field should be set at zero value for immediate data types (i32, i64 and bool, which are all embedded into an i64 container), as any nonzero value will identify a pointer usage of the union. Tested on x86_64 and aarch64.