### PR TITLE
Upgrade to `bitflags 2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository= "https://github.com/raymanfx/libv4l-rs"
 
 [dependencies]
-bitflags = "1.2.1"
+bitflags = "2"
 libc = "0.2"
 v4l-sys = { path = "v4l-sys", version = "0.3.0", optional = true }
 v4l2-sys = { path = "v4l2-sys", version = "0.3.0", package="v4l2-sys-mit", optional = true }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,4 +1,3 @@
-use bitflags::bitflags;
 use std::fmt;
 
 use crate::timestamp::Timestamp;
@@ -30,8 +29,8 @@ pub enum Type {
     Private             = 0x80,
 }
 
-bitflags! {
-    #[allow(clippy::unreadable_literal)]
+bitflags::bitflags! {
+    #[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
     pub struct Flags: u32 {
         /// Buffer is mapped
         const MAPPED                = 0x00000001;

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -1,10 +1,9 @@
-use bitflags::bitflags;
 use std::{fmt, str};
 
 use crate::v4l_sys::*;
 
-bitflags! {
-    #[allow(clippy::unreadable_literal)]
+bitflags::bitflags! {
+    #[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
     pub struct Flags: u32 {
         const VIDEO_CAPTURE         = 0x00000001;
         const VIDEO_OUTPUT          = 0x00000002;

--- a/src/control.rs
+++ b/src/control.rs
@@ -1,4 +1,3 @@
-use bitflags::bitflags;
 use std::convert::{TryFrom, TryInto};
 use std::{ffi, fmt, mem, str};
 
@@ -63,8 +62,8 @@ impl fmt::Display for Type {
     }
 }
 
-bitflags! {
-    #[allow(clippy::unreadable_literal)]
+bitflags::bitflags! {
+    #[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
     pub struct Flags: u32 {
         const DISABLED              = 0x0001;
         const GRABBED               = 0x0002;

--- a/src/format/description.rs
+++ b/src/format/description.rs
@@ -1,11 +1,10 @@
-use bitflags::bitflags;
 use std::{fmt, str};
 
 use crate::format::FourCC;
 use crate::v4l_sys::*;
 
-bitflags! {
-    #[allow(clippy::unreadable_literal)]
+bitflags::bitflags! {
+    #[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
     pub struct Flags : u32 {
         const COMPRESSED            = 0x0001;
         const EMULATED              = 0x0002;

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -1,4 +1,3 @@
-use bitflags::bitflags;
 use std::{convert::TryFrom, fmt, mem};
 
 use crate::v4l_sys::*;
@@ -21,8 +20,8 @@ pub use quantization::Quantization;
 pub mod transfer;
 pub use transfer::TransferFunction;
 
-bitflags! {
-    #[allow(clippy::unreadable_literal)]
+bitflags::bitflags! {
+    #[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
     pub struct Flags : u32 {
         const PREMUL_ALPHA  = 0x00000001;
     }

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -1,9 +1,8 @@
-use bitflags::bitflags;
 use std::fmt;
 
-bitflags! {
+bitflags::bitflags! {
+    #[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
     pub struct Capabilities: u32 {
-        #[allow(clippy::unreadable_literal)]
         const TIME_PER_FRAME    = 0x1000;
     }
 }

--- a/src/v4l2/api.rs
+++ b/src/v4l2/api.rs
@@ -40,7 +40,7 @@ mod detail {
     ) -> *mut std::os::raw::c_void {
         // libv4l expects `request` to be a u64, but this is not guaranteed on all platforms.
         // For the default CI platform (x86_64) clippy will complain about a useless conversion.
-        #![allow(clippy::useless_conversion)]
+        #![allow(clippy::useless_conversion, clippy::unnecessary_cast)]
         v4l2_mmap(
             start,
             length.try_into().expect("usize -> c size_t failed"),
@@ -51,6 +51,7 @@ mod detail {
         )
     }
     pub unsafe fn munmap(start: *mut std::os::raw::c_void, length: usize) -> std::os::raw::c_int {
+        #![allow(clippy::useless_conversion)]
         v4l2_munmap(start, length.try_into().expect("usize -> c size_t failed"))
     }
 }

--- a/src/video/capture/parameters.rs
+++ b/src/video/capture/parameters.rs
@@ -1,11 +1,11 @@
-use bitflags::bitflags;
 use std::{fmt, mem};
 
 use crate::fraction::Fraction;
 use crate::parameters::Capabilities;
 use crate::v4l_sys::*;
 
-bitflags! {
+bitflags::bitflags! {
+    #[derive(PartialEq, Eq, Hash, Debug, Clone, Copy)]
     pub struct Modes: u32 {
         const HIGH_QUALITY      = 0x1000;
     }


### PR DESCRIPTION
CI throws an `clippy::bad_bit_mask` that has been fixed in `bitflags 2` [1], and it is always a good idea to stay up to date with the latest crate releases.

The major change is an internal restructuring into _two_ types, that require the user to now re-expose default traits implemented on the inner type to the outer type by `#[derive]`'ing them.

[1]: https://github.com/bitflags/bitflags/pull/373

---

On the side I'm not super happy with the `From` implementations using `from_bits_truncate()` to be lossy, in case the kernel adds newer values that we haven't yet mapped as constants: can we separately switch to `from_bits_retain()`?
