### PR TITLE
Retain instead of truncate unknown flags when converting to `bitflags`

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -81,7 +81,7 @@ impl Default for Flags {
 
 impl From<u32> for Flags {
     fn from(flags: u32) -> Self {
-        Self::from_bits_truncate(flags)
+        Self::from_bits_retain(flags)
     }
 }
 

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -45,7 +45,7 @@ bitflags::bitflags! {
 
 impl From<u32> for Flags {
     fn from(flags: u32) -> Self {
-        Self::from_bits_truncate(flags)
+        Self::from_bits_retain(flags)
     }
 }
 

--- a/src/control.rs
+++ b/src/control.rs
@@ -84,7 +84,7 @@ bitflags::bitflags! {
 
 impl From<u32> for Flags {
     fn from(flags: u32) -> Self {
-        Self::from_bits_truncate(flags)
+        Self::from_bits_retain(flags)
     }
 }
 

--- a/src/format/description.rs
+++ b/src/format/description.rs
@@ -15,7 +15,7 @@ bitflags::bitflags! {
 
 impl From<u32> for Flags {
     fn from(flags: u32) -> Self {
-        Self::from_bits_truncate(flags)
+        Self::from_bits_retain(flags)
     }
 }
 

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -29,7 +29,7 @@ bitflags::bitflags! {
 
 impl From<u32> for Flags {
     fn from(flags: u32) -> Self {
-        Self::from_bits_truncate(flags)
+        Self::from_bits_retain(flags)
     }
 }
 

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -9,7 +9,7 @@ bitflags::bitflags! {
 
 impl From<u32> for Capabilities {
     fn from(caps: u32) -> Self {
-        Self::from_bits_truncate(caps)
+        Self::from_bits_retain(caps)
     }
 }
 

--- a/src/video/capture/parameters.rs
+++ b/src/video/capture/parameters.rs
@@ -13,7 +13,7 @@ bitflags::bitflags! {
 
 impl From<u32> for Modes {
     fn from(caps: u32) -> Self {
-        Self::from_bits_truncate(caps)
+        Self::from_bits_retain(caps)
     }
 }
 


### PR DESCRIPTION
Depends on #79

`bitflags` intrinsically supports holding unknown flag values, and pretty-printing a non-zero hex code if there are any.  This should make our conversion functions lossless and allow us/users to more easily spot new, unsupported constants.
