### PR TITLE
README: Use GitHub Actions badge instead of dysfunct Travis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,116 +6,166 @@ Changelog items are created for major and minor releases, but not bugfix ones fo
 Currently, the focus is on implementing the high-level V4L2 single-planar API.
 Multi-planar capture will not be targeted in the near future unless someone else starts working on it.
 
-
-
 ## [0.14.0] - 2023-05-13
+
 ### Added
+
 - Expose raw file descriptor of streams through `Stream::handle()`
+
 ### Changed
+
 - Updated `bindgen` dependency to 0.65.1
+
 ### Fixed
+
 - Use proper C FFI struct field for `Integer64` controls
 - Fix example in README.md to account for the negotiated pixelformat
 
 ## [0.13.1] - 2022-12-08
+
 ### Fixed
+
 - Do not block when the device is disconnected
   - This is achieved by using the non-blocking file descriptor API internally
   - The outside-facing API is the same for now
   - Can be used as a foundation for language-level async support in the future
 
 ## [0.13.0] - 2022-05-19
+
 ### Added
+
 - Handling of boolean and button controls
 - MJPG (consumer class hardware) support in `glium` example
+
 ### Changed
+
 - Simplified examples, removing clap argument parsing
 - Unified Value/Value64 control types into a single Integer enum variant
+
 ### Fixed
+
 - MUSL libc compatibility
 - Android cross compilation
 
 ## [0.12.2] - 2021-19-01
+
 ### Fixed
+
 - Avoid dropping frames by queuing all buffers on stream start
 
 ## [0.12.1] - 2021-05-01
+
 ### Fixed
+
 - Update the buffer index for output streams
 - Honor the bytesused field for compressed frames in output streams
 
 ## [0.12.0] - 2021-01-07
+
 ### Changed
+
 - Depend on `0.2.0` sys packages to ship bindgen 0.56.0
 
 ## [0.11] - 2020-12-31
+
 ### Added
+
 - Global context struct
   - Used to enumerate devices
 - Single, unified device struct
   - Implement Capture / Output capabilities as traits
 - MMAP support for output streams (see `stream_forward_mmap` example)
+
 ### Changed
+
 - Fine grained buffer access and handling for streams
 
 ## [0.10] - 2020-08-26
+
 ### Added
+
 - Output device support!
   - Just the single-planar API for now.
   - Only write() I/O, no mmap or other buffer types.
 
 ## [0.9] - 2020-08-05
+
 ### Added
+
 - New Handle type for passing around device handles
   - You can now stream buffers while changing device controls at the same time! Handles are
     thread safe (Arc) by default.
 - New StreamItem type introduced to better model stream semantics
   - An item only lives up to the point in time where you query the next item from the stream.
+
 ### Removed
+
 - Removed buffer arenas from public API
 
 ## [0.8] - 2020-08-01
+
 ### Added
+
 - New prelude module
+
 ### Changed
+
 - I/O module reorganization
 - Renamed BufferManagers to Arenas
 - Use a single Buffer struct for all I/O streams
+
 ### Removed
+
 - Removed the 'get_' prefix on getters
 
 ## [0.7] - 2020-07-06
+
 ### Added
+
 - Device control get/set support
 - New QueryDevice trait
   - Implemented for all types which implement Device
   - Allows for querying properties such as supported frame times and controls
 
 ## [0.6] - 2020-07-04
+
 ### Added
+
 - Device control query support
+
 ### Changed
+
 - Use v4l2 bindings by default
 
 ## [0.5] - 2020-05-14
+
 ### Changed
+
 - Device API refactoring
   - We only support the V4L2 capture API for now
   - Overlay, Output and friends will be added in future releases
 
 ## [0.4] - 2020-05-03
+
 ### Added
+
 - Streaming I/O (userptr)
+
 ### Changed
+
 - Optional libv4l vs v4l2 FFI dependencies
 
 ## [0.3] - 2020-05-02
+
 ### Added
+
 - Device buffer abstraction
   - Streaming I/O (mmap)
 
 ## [0.2] - 2020-05-01
+
 ### Added
+
 - Device list with capability querying
 - Device abstraction
   - Format enumeration
@@ -123,6 +173,8 @@ Multi-planar capture will not be targeted in the near future unless someone else
   - Parameter getter/setter
 
 ## [0.1] - 2020-04-30
+
 ### Added
+
 - v4l-sys bindings
 - I/O codes (VIDIOC_*)

--- a/README.md
+++ b/README.md
@@ -1,34 +1,40 @@
 # Safe video4linux (v4l) bindings
 
-[![crates.io](https://img.shields.io/crates/v/v4l.svg?style=for-the-badge)](https://crates.io/crates/v4l)
-[![license](https://img.shields.io/github/license/raymanfx/libv4l-rs?style=for-the-badge)](https://github.com/raymanfx/libv4l-rs/blob/master/LICENSE.txt)
-[![Build Status](https://img.shields.io/travis/raymanfx/libv4l-rs/master.svg?style=for-the-badge&logo=travis)](https://travis-ci.org/raymanfx/libv4l-rs)
+[![CI](https://github.com/raymanfx/libv4l-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/raymanfx/libv4l-rs/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/v4l.svg?logo=rust)](https://crates.io/crates/v4l)
+[![Documentation](https://docs.rs/v4l/badge.svg)](https://docs.rs/v4l)
+[![license](https://img.shields.io/github/license/raymanfx/libv4l-rs)](https://github.com/raymanfx/libv4l-rs/blob/master/LICENSE.txt)
 
 This crate provides safe bindings to the Video for Linux (V4L) stack. Modern device drivers will usually implement the `v4l2` API while older ones may depend on the legacy `v4l` API. Such legacy devices may be used with this crate by choosing the `libv4l` feature for this crate.
 
 ## Goals
-This crate shall provide the v4l-sys package to enable full (but unsafe) access to libv4l\*.
+
+This crate shall provide the `v4l-sys` package to enable full (but unsafe) access to `libv4l*`.
 On top of that, there will be a high level, more idiomatic API to use video capture devices in Linux.
 
 There will be simple utility applications to list devices and capture frames.
 A minimalistic OpenGL/Vulkan viewer to display frames is planned for the future.
 
 ## Changelog
-See [CHANGELOG.md](https://github.com/raymanfx/libv4l-rs/blob/master/CHANGELOG.md)
+
+See [CHANGELOG.md](./CHANGELOG.md)
 
 ## Dependencies
+
 You have the choice between two dependencies (both provided by this crate internally):
- * libv4l-sys
+
+* `libv4l-sys`
    > Link against the libv4l* stack including libv4l1, libv4l2, libv4lconvert.
    > This has the advantage of emulating common capture formats such as RGB3 in userspace through libv4lconvert and more.
    > However, some features like userptr buffers are not supported in libv4l.
- * v4l2-sys
+* `v4l2-sys`
    > Use only the Linux kernel provided v4l2 API provided by videodev2.h.
    > You get support for all v4l2 features such as userptr buffers, but may need to do format conversion yourself if you require e.g. RGB/BGR buffers which may not be supported by commodity devices such as webcams.
 
 Enable either the `libv4l` or the `v4l2` backend by choosing the it as feature for this crate.
 
 ## Usage
+
 Below you can find a quick example usage of this crate. It introduces the basics necessary to do frame capturing from a streaming device (e.g. webcam).
 
 ```rust


### PR DESCRIPTION
Seems the last successful build there was 2 years ago, and the badge now says "Build: No longer available".  Switch the badge over to reflect the CI status on GitHub Actions instead.

~Note that there is unfortunately no `for-the-badge` style available here to match the other badges, which we should perhaps update to match GitHub's style instead?~

Also add a badge linking to the documentation of the main `v4l` crate, wrap some crate names in backticks, and format the markdown documents to have proper spacing around headings.