### PR TITLE
Add dependabot configuration to GitHub CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /.github/workflows/
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Let dependabot suggest dependency upgrades in `Cargo.toml` and the GitHub Actions CI scripts so that we don't forget / miss out on them.
