### PR TITLE
device: Retry `poll()` on interrupts (`EINTR`)

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -394,7 +394,13 @@ impl Handle {
                 timeout,
             )
         } {
-            -1 => Err(io::Error::last_os_error()),
+            -1 => {
+                let e = io::Error::last_os_error();
+                match e.kind() {
+                    io::ErrorKind::Interrupted => self.poll(events, timeout),
+                    _ => Err(e),
+                }
+            },
             ret => {
                 // A return value of zero means that we timed out. A positive value signifies the
                 // number of fds with non-zero revents fields (aka I/O activity).


### PR DESCRIPTION
Attempt at handling EINTR in the case of a system call interrupt when polling for events.

Fixed an issue with a little program I wrote [asciicam](https://github.com/vilhelmbergsoe/asciicam), which would panic with the error message "Error: Interrupted system call (os error 4)" when calling stream.next() after and upgrade from 0.13.0 -> 0.14.0.

I don't have a deep understanding of interruptible syscalls, but apparently the event polling from libv4l-rs is also connected to keyboard input in the terminal somehow?

While looking this up I came across a similar issue with crossterm [here](https://github.com/crossterm-rs/crossterm/issues/755). They seem to have fixed it by continuing in the loop over polls, the PR is [here](https://github.com/crossterm-rs/crossterm/pull/762).

This solution isn't as elegant as I just do a recursive call to poll and hope there isn't an interrupt next time, but it seems to work in my program.