### PR TITLE
Add static bindgen linking options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,11 @@ glium = "0.27.0"
 jpeg-decoder = "0.3.0"
 
 [features]
-default = ["v4l2"]
+default = ["v4l2", "runtime"]
 libv4l = ["v4l-sys"]
 v4l2 = ["v4l2-sys"]
+runtime = ["v4l-sys?/runtime", "v4l2-sys?/runtime"]
+static = ["v4l-sys?/static", "v4l2-sys?/static"]
 
 [workspace]
 members = [

--- a/v4l-sys/Cargo.toml
+++ b/v4l-sys/Cargo.toml
@@ -9,7 +9,7 @@ links = "v4l1 v4l2 v4lconvert"
 build = "build.rs"
 
 [build-dependencies]
-bindgen = { version = "0.69.1", default-features = false }
+bindgen = { git = "https://github.com/callum-hopkins-dev/rust-bindgen.git", rev = "d353b4889e446ee37347f8e19de985c1e24761b5", default-features = false }
 
 [features]
 runtime = ["bindgen/runtime"]

--- a/v4l-sys/Cargo.toml
+++ b/v4l-sys/Cargo.toml
@@ -9,4 +9,9 @@ links = "v4l1 v4l2 v4lconvert"
 build = "build.rs"
 
 [build-dependencies]
-bindgen = "0.69.1"
+bindgen = { version = "0.69.1", default-features = false }
+
+[features]
+runtime = ["bindgen/runtime"]
+static = ["bindgen/static"]
+

--- a/v4l2-sys/Cargo.toml
+++ b/v4l2-sys/Cargo.toml
@@ -8,4 +8,8 @@ license = "MIT"
 build = "build.rs"
 
 [build-dependencies]
-bindgen = "0.69.1"
+bindgen = { version = "0.69.1", default-features = false }
+
+[features]
+runtime = ["bindgen/runtime"]
+static = ["bindgen/static"]

--- a/v4l2-sys/Cargo.toml
+++ b/v4l2-sys/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 build = "build.rs"
 
 [build-dependencies]
-bindgen = { version = "0.69.1", default-features = false }
+bindgen = { git = "https://github.com/callum-hopkins-dev/rust-bindgen.git", rev = "d353b4889e446ee37347f8e19de985c1e24761b5", default-features = false }
 
 [features]
 runtime = ["bindgen/runtime"]


### PR DESCRIPTION
This PR adds two new features: `static` and `runtime` with the latter being enabled by default.

When the `runtime` feature is enabled, the crate will compile the same as before, since bindgen enables runtime linking by default. However, when the `static` feature is enabled, bindgen will link `libclang` and other toolchain infrastructure as static libraries.

Static linking is useful for building projects on `musl` based linux distributions such as alpine, since they do not support dynamic linking easily. Moreover, static linking is more aligned with rust's general compilation philosophies and this PR gives users the options to enable it.