### PR TITLE
CI: Replace deprecated/unmaintained `actions-rs` with simple `run:` steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,21 +11,10 @@ jobs:
     steps:
       - run: sudo apt-get install libv4l-dev
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        name: Check `v4l2`
-        with:
-          command: check
-          args: --workspace --all-targets
-      - uses: actions-rs/cargo@v1
-        name: Check `libv4l`
-        with:
-          command: check
-          args: --workspace --all-targets --no-default-features --features libv4l
+      - name: Check `v4l2`
+        run: cargo check --workspace --all-targets
+      - name: Check `libv4l`
+        run: cargo check --workspace --all-targets --no-default-features --features libv4l
 
   test:
     name: Test
@@ -33,37 +22,17 @@ jobs:
     steps:
       - run: sudo apt-get install libv4l-dev
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
       - name: Test all targets
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --all-targets
+        run: cargo test --workspace --all-targets
       - name: Test docs
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --doc
+        run: cargo test --workspace --doc
 
   fmt:
     name: Rustfmt
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
@@ -71,22 +40,10 @@ jobs:
     steps:
       - run: sudo apt-get install libv4l-dev
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: clippy
-      - uses: actions-rs/cargo@v1
-        name: Clippy lint `v4l2`
-        with:
-          command: clippy
-          args: --workspace --all-targets -- -D warnings
-      - uses: actions-rs/cargo@v1
-        name: Clippy lint `libv4l`
-        with:
-          command: clippy
-          args: --workspace --all-targets --no-default-features --features libv4l -- -D warnings
+      - name: Clippy lint `v4l2`
+        run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: Clippy lint `libv4l`
+        run: cargo clippy --workspace --all-targets --no-default-features --features libv4l -- -D warnings
 
   docs:
     name: Build-test docs
@@ -94,15 +51,7 @@ jobs:
     steps:
       - run: sudo apt-get install libv4l-dev
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        name: Document all crates
+      - name: Document all crates
         env:
           RUSTDOCFLAGS: -Dwarnings
-        with:
-          command: doc
-          args: --workspace --no-deps --document-private-items
+        run: cargo doc --workspace --no-deps --document-private-items


### PR DESCRIPTION
The `actions-rs` containers haven't been maintained and updated for years and don't need to: GitHub's actions environment already comes fully loaded with a complete stable Rust installation with the standard tools (clippy, rustfmt, rustdoc).  Simple `run:` commands relate directly to what a developer can type in locally to "reproduce" the CI environment while they might be following up on CI failures, and no longer spam ancient Node 12 deprecation warnings.

The only downside is that `actions-rs` properly embeds build failures as code annotations in the diff.