### PR TITLE
Add FreeBSD support

### DIFF
--- a/src/v4l2/api.rs
+++ b/src/v4l2/api.rs
@@ -66,6 +66,7 @@ mod detail {
     pub unsafe fn close(fd: std::os::raw::c_int) -> std::os::raw::c_int {
         libc::close(fd)
     }
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     pub unsafe fn ioctl(
         fd: std::os::raw::c_int,
         request: vidioc::_IOC_TYPE,
@@ -79,6 +80,14 @@ mod detail {
          * https://github.com/rust-lang/libc/issues/1036
          */
         libc::syscall(libc::SYS_ioctl, fd, request, argp) as std::os::raw::c_int
+    }
+    #[cfg(target_os = "freebsd")]
+    pub unsafe fn ioctl(
+        fd: std::os::raw::c_int,
+        request: vidioc::_IOC_TYPE,
+        argp: *mut std::os::raw::c_void,
+    ) -> std::os::raw::c_int {
+        libc::ioctl(fd, request, argp)
     }
     pub unsafe fn mmap(
         start: *mut std::os::raw::c_void,

--- a/src/v4l2/vidioc.rs
+++ b/src/v4l2/vidioc.rs
@@ -19,8 +19,16 @@ const _IOC_SIZESHIFT: u8 = _IOC_TYPESHIFT + _IOC_TYPEBITS;
 const _IOC_DIRSHIFT: u8 = _IOC_SIZESHIFT + _IOC_SIZEBITS;
 
 const _IOC_NONE: u8 = 0;
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const _IOC_WRITE: u8 = 1;
+#[cfg(target_os = "freebsd")]
+const _IOC_WRITE: u8 = 2;
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const _IOC_READ: u8 = 2;
+#[cfg(target_os = "freebsd")]
+const _IOC_READ: u8 = 1;
 
 macro_rules! _IOC_TYPECHECK {
     ($type:ty) => {

--- a/v4l2-sys/Cargo.toml
+++ b/v4l2-sys/Cargo.toml
@@ -9,3 +9,4 @@ build = "build.rs"
 
 [build-dependencies]
 bindgen = "0.69.1"
+pkg-config = "0.3.30"

--- a/v4l2-sys/build.rs
+++ b/v4l2-sys/build.rs
@@ -4,8 +4,18 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
+    let pkg_conf = pkg_config::Config::new()
+        .probe("libv4l2")
+        .expect("pkg-config has failed to find `libv4l2`");
+
     let bindings = bindgen::Builder::default()
         .header("wrapper.h")
+        .clang_args(
+            pkg_conf
+                .include_paths
+                .into_iter()
+                .map(|path| format!("-I{}", path.to_string_lossy())),
+        )
         .generate()
         .expect("Failed to generate bindings");
 


### PR DESCRIPTION
I've used the proposed changes on a recent `FreeBSD CURRENT` with `amd64` (i.e. `x86_64`) architecture with `Logitech C922 Pro` webcam.

What works:
- video stream capturing via `MmapStream`
- querying and changing capturing formats
- querying and altering camera controls

What doesn't work:
- video stream capturing via `UserptrStream`