### PR TITLE
Feature/custom userptr allocator to take into account special hardware-aligment requirements for some v4l devices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository= "https://github.com/raymanfx/libv4l-rs"
 [dependencies]
 bitflags = "1.2.1"
 libc = "0.2"
+allocator-api2 = "0.2.18"
 v4l-sys = { path = "v4l-sys", version = "0.3.0", optional = true }
 v4l2-sys = { path = "v4l2-sys", version = "0.3.0", package="v4l2-sys-mit", optional = true }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -30,49 +30,55 @@ pub enum Type {
     Private             = 0x80,
 }
 
-bitflags! {
-    #[allow(clippy::unreadable_literal)]
-    pub struct Flags: u32 {
-        /// Buffer is mapped
-        const MAPPED                = 0x00000001;
-        /// Buffer is queued for processing
-        const QUEUED                = 0x00000002;
-        /// Buffer is ready
-        const DONE                  = 0x00000004;
-        /// Image is a keyframe (I-frame)
-        const KEYFRAME              = 0x00000008;
-        /// Image is a P-frame
-        const PFRAME                = 0x00000010;
-        /// Image is a B-frame
-        const BFRAME                = 0x00000020;
-        /// Buffer is ready, but the data contained within is corrupted
-        const ERROR                 = 0x00000040;
-        /// Buffer is added to an unqueued request
-        const IN_REQUEST            = 0x00000080;
-        /// Timecode field is valid
-        const TIMECODE              = 0x00000100;
-        /// Don't return the capture buffer until OUTPUT timestamp changes
-        const M2M_HOLD_CAPTURE_BUF  = 0x00000200;
-        /// Buffer is prepared for queuing
-        const PREPARED              = 0x00000400;
-        /// Cache handling flags
-        const NO_CACHE_INVALIDATE   = 0x00000800;
-        const NO_CACHE_CLEAN        = 0x00001000;
-        /// Timestamp type
-        const TIMESTAMP_MASK        = 0x0000e000;
-        const TIMESTAMP_UNKNOWN     = 0x00000000;
-        const TIMESTAMP_MONOTONIC   = 0x00002000;
-        const TIMESTAMP_COPY        = 0x00004000;
-        /// Timestamp sources
-        const TSTAMP_SRC_MASK       = 0x00070000;
-        const TSTAMP_SRC_EOF        = 0x00000000;
-        const TSTAMP_SRC_SOE        = 0x00010000;
-        /// mem2mem encoder/decoder
-        const LAST                  = 0x00100000;
-        /// request_fd is valid
-        const REQUEST_FD            = 0x00800000;
+// Module trick to make it possible to allow the clippy warning of the output of a macro
+#[allow(clippy::bad_bit_mask)]
+mod flags {
+    use bitflags::bitflags;
+    bitflags! {
+        #[allow(clippy::unreadable_literal)]
+        pub struct Flags: u32 {
+            /// Buffer is mapped
+            const MAPPED                = 0x00000001;
+            /// Buffer is queued for processing
+            const QUEUED                = 0x00000002;
+            /// Buffer is ready
+            const DONE                  = 0x00000004;
+            /// Image is a keyframe (I-frame)
+            const KEYFRAME              = 0x00000008;
+            /// Image is a P-frame
+            const PFRAME                = 0x00000010;
+            /// Image is a B-frame
+            const BFRAME                = 0x00000020;
+            /// Buffer is ready, but the data contained within is corrupted
+            const ERROR                 = 0x00000040;
+            /// Buffer is added to an unqueued request
+            const IN_REQUEST            = 0x00000080;
+            /// Timecode field is valid
+            const TIMECODE              = 0x00000100;
+            /// Don't return the capture buffer until OUTPUT timestamp changes
+            const M2M_HOLD_CAPTURE_BUF  = 0x00000200;
+            /// Buffer is prepared for queuing
+            const PREPARED              = 0x00000400;
+            /// Cache handling flags
+            const NO_CACHE_INVALIDATE   = 0x00000800;
+            const NO_CACHE_CLEAN        = 0x00001000;
+            /// Timestamp type
+            const TIMESTAMP_MASK        = 0x0000e000;
+            const TIMESTAMP_UNKNOWN     = 0x00000000;
+            const TIMESTAMP_MONOTONIC   = 0x00002000;
+            const TIMESTAMP_COPY        = 0x00004000;
+            /// Timestamp sources
+            const TSTAMP_SRC_MASK       = 0x00070000;
+            const TSTAMP_SRC_EOF        = 0x00000000;
+            const TSTAMP_SRC_SOE        = 0x00010000;
+            /// mem2mem encoder/decoder
+            const LAST                  = 0x00100000;
+            /// request_fd is valid
+            const REQUEST_FD            = 0x00800000;
+        }
     }
 }
+use flags::*;
 
 impl Default for Flags {
     fn default() -> Self {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,4 +1,3 @@
-use bitflags::bitflags;
 use std::fmt;
 
 use crate::timestamp::Timestamp;

--- a/src/io/userptr/mod.rs
+++ b/src/io/userptr/mod.rs
@@ -1,4 +1,4 @@
 pub(crate) mod arena;
 
 pub mod stream;
-pub use stream::Stream;
+pub use stream::{AllocStream, Stream};


### PR DESCRIPTION
Hi there.

When using the userptr io-mode for V4L, the v4l driver can have special alignment requirements for the buffers that are given to it.
I hit this limitation experimenting with the V4L2 drivers for CSI cameras on Nvidia Tegra devices.

This PR tries to allow for specifying custom allocators for the crate in a backwards compatible way, and I thought it would be nice to contribute it back to upstream.
If there are any things you would like different, or require changes, please don't hesitate to mention it.

Regards Morten
