### PR TITLE
BREAKING CHANGE: Spelling Fix for `Type::VbiCaputre`

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -13,7 +13,7 @@ pub enum Type {
     VideoCapture        = 1,
     VideoOutput         = 2,
     VideoOverlay        = 3,
-    VbiCaputre          = 4,
+    VbiCapture          = 4,
     VbiOutput           = 5,
     SlicedVbiCapture    = 6,
     SlicedVbiOutput     = 7,


### PR DESCRIPTION
This is a teeny tiny change to fix the spelling for the `VbiCaputre` variant in the `buffer::Type` enum. Note that a major version bump is required to avoid violating semantic versioning. 