### PR TITLE
FourCC: Improve debug prints

### DIFF
--- a/src/format/fourcc.rs
+++ b/src/format/fourcc.rs
@@ -1,6 +1,6 @@
 use std::{fmt, str};
 
-#[derive(Debug, Default, Copy, Clone, Eq)]
+#[derive(Default, Copy, Clone, Eq)]
 /// Four character code representing a pixelformat
 pub struct FourCC {
     pub repr: [u8; 4],
@@ -38,6 +38,20 @@ impl FourCC {
     }
 }
 
+impl fmt::Debug for FourCC {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let string = str::from_utf8(&self.repr);
+        if let Ok(string) = string {
+            write!(f, "FourCC(")?;
+            string.fmt(f)?;
+            write!(f, ")")?;
+        } else {
+            write!(f, "FourCC({:02x} {:02x} {:02x} {:02x})", self.repr[0], self.repr[1], self.repr[2], self.repr[3])?;
+        }
+        Ok(())
+    }
+}
+
 impl fmt::Display for FourCC {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let string = str::from_utf8(&self.repr);
@@ -63,5 +77,21 @@ impl From<u32> for FourCC {
 impl From<FourCC> for u32 {
     fn from(fourcc: FourCC) -> Self {
         Self::from_le_bytes(fourcc.repr)
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_fourcc_string() {
+        assert_eq!(format!("{:?}", FourCC::new(b"MJPG")), "FourCC(\"MJPG\")");
+    }
+
+    #[test]
+    fn debug_fourcc_nonascii() {
+        assert_eq!(format!("{:?}", FourCC::new(&[0x01, 0xff, 0x20, 0xcd])), "FourCC(01 ff 20 cd)");
     }
 }


### PR DESCRIPTION
This looks bad:

```
FourCC {
                repr: [
                    89,
                    85,
                    89,
                    86,
                ],
            },
```

This looks better:

```
FourCC("YUYV"),
```

Fallback for non-ASCII:

```
FourCC(01 ff 20 cd)
```

I think [drm_fourcc](https://docs.rs/drm-fourcc/latest/drm_fourcc/) is a better choice for representing fourcc in Linux, but I'm not ready to propose such a change.