### PR TITLE
Remove unnecessary lifetime parameters

### DIFF
--- a/src/io/mmap/arena.rs
+++ b/src/io/mmap/arena.rs
@@ -10,13 +10,13 @@ use crate::v4l_sys::*;
 ///
 /// All buffers are unmapped in the Drop impl.
 /// In case of errors during unmapping, we panic because there is memory corruption going on.
-pub struct Arena<'a> {
+pub struct Arena {
     handle: Arc<Handle>,
-    pub bufs: Vec<&'a mut [u8]>,
+    pub bufs: Vec<*mut [u8]>,
     pub buf_type: buffer::Type,
 }
 
-impl<'a> Arena<'a> {
+impl Arena {
     /// Returns a new buffer manager instance
     ///
     /// You usually do not need to use this directly.
@@ -94,9 +94,9 @@ impl<'a> Arena<'a> {
     }
 
     pub fn release(&mut self) -> io::Result<()> {
-        for buf in &self.bufs {
+        for &buf in &self.bufs {
             unsafe {
-                v4l2::munmap(buf.as_ptr() as *mut core::ffi::c_void, buf.len())?;
+                v4l2::munmap(buf as *mut core::ffi::c_void, buf.len())?;
             }
         }
 
@@ -118,7 +118,7 @@ impl<'a> Arena<'a> {
     }
 }
 
-impl<'a> Drop for Arena<'a> {
+impl Drop for Arena {
     fn drop(&mut self) {
         if self.bufs.is_empty() {
             // nothing to do

--- a/src/io/mmap/stream.rs
+++ b/src/io/mmap/stream.rs
@@ -13,9 +13,9 @@ use crate::v4l_sys::*;
 /// Stream of mapped buffers
 ///
 /// An arena instance is used internally for buffer handling.
-pub struct Stream<'a> {
+pub struct Stream {
     handle: Arc<Handle>,
-    arena: Arena<'a>,
+    arena: Arena,
     arena_index: usize,
     buf_type: Type,
     buf_meta: Vec<Metadata>,
@@ -24,7 +24,7 @@ pub struct Stream<'a> {
     active: bool,
 }
 
-impl<'a> Stream<'a> {
+impl Stream {
     /// Returns a stream for frame capturing
     ///
     /// # Arguments
@@ -89,7 +89,7 @@ impl<'a> Stream<'a> {
     }
 }
 
-impl<'a> Drop for Stream<'a> {
+impl Drop for Stream {
     fn drop(&mut self) {
         if let Err(e) = self.stop() {
             if let Some(code) = e.raw_os_error() {
@@ -107,7 +107,7 @@ impl<'a> Drop for Stream<'a> {
     }
 }
 
-impl<'a> StreamTrait for Stream<'a> {
+impl StreamTrait for Stream {
     type Item = [u8];
 
     fn start(&mut self) -> io::Result<()> {
@@ -139,7 +139,7 @@ impl<'a> StreamTrait for Stream<'a> {
     }
 }
 
-impl<'a, 'b> CaptureStream<'b> for Stream<'a> {
+impl CaptureStream for Stream {
     fn queue(&mut self, index: usize) -> io::Result<()> {
         let mut v4l2_buf = v4l2_buffer {
             index: index as u32,
@@ -187,7 +187,7 @@ impl<'a, 'b> CaptureStream<'b> for Stream<'a> {
         Ok(self.arena_index)
     }
 
-    fn next(&'b mut self) -> io::Result<(&Self::Item, &Metadata)> {
+    fn next(&mut self) -> io::Result<(&Self::Item, &Metadata)> {
         if !self.active {
             // Enqueue all buffers once on stream start
             for index in 0..self.arena.bufs.len() {
@@ -203,13 +203,14 @@ impl<'a, 'b> CaptureStream<'b> for Stream<'a> {
 
         // The index used to access the buffer elements is given to us by v4l2, so we assume it
         // will always be valid.
-        let bytes = &self.arena.bufs[self.arena_index];
+        let bytes = self.arena.bufs[self.arena_index];
+        let bytes = unsafe { &*bytes };
         let meta = &self.buf_meta[self.arena_index];
         Ok((bytes, meta))
     }
 }
 
-impl<'a, 'b> OutputStream<'b> for Stream<'a> {
+impl OutputStream for Stream {
     fn queue(&mut self, index: usize) -> io::Result<()> {
         let mut v4l2_buf = v4l2_buffer {
             index: index as u32,
@@ -266,7 +267,7 @@ impl<'a, 'b> OutputStream<'b> for Stream<'a> {
         Ok(self.arena_index)
     }
 
-    fn next(&'b mut self) -> io::Result<(&mut Self::Item, &mut Metadata)> {
+    fn next(&mut self) -> io::Result<(&mut Self::Item, &mut Metadata)> {
         let init = !self.active;
         if !self.active {
             self.start()?;
@@ -282,7 +283,8 @@ impl<'a, 'b> OutputStream<'b> for Stream<'a> {
 
         // The index used to access the buffer elements is given to us by v4l2, so we assume it
         // will always be valid.
-        let bytes = &mut self.arena.bufs[self.arena_index];
+        let bytes = self.arena.bufs[self.arena_index];
+        let bytes = unsafe { &mut *bytes };
         let meta = &mut self.buf_meta[self.arena_index];
         Ok((bytes, meta))
     }

--- a/src/io/traits.rs
+++ b/src/io/traits.rs
@@ -13,7 +13,7 @@ pub trait Stream {
     fn stop(&mut self) -> io::Result<()>;
 }
 
-pub trait CaptureStream<'a>: Stream {
+pub trait CaptureStream: Stream {
     /// Insert a buffer into the drivers' incoming queue
     fn queue(&mut self, index: usize) -> io::Result<()>;
 
@@ -22,10 +22,10 @@ pub trait CaptureStream<'a>: Stream {
 
     /// Fetch a new frame by first queueing and then dequeueing.
     /// First time initialization is performed if necessary.
-    fn next(&'a mut self) -> io::Result<(&Self::Item, &Metadata)>;
+    fn next(&mut self) -> io::Result<(&Self::Item, &Metadata)>;
 }
 
-pub trait OutputStream<'a>: Stream {
+pub trait OutputStream: Stream {
     /// Insert a buffer into the drivers' incoming queue
     fn queue(&mut self, index: usize) -> io::Result<()>;
 
@@ -34,5 +34,5 @@ pub trait OutputStream<'a>: Stream {
 
     /// Dump a new frame by first queueing and then dequeueing.
     /// First time initialization is performed if necessary.
-    fn next(&'a mut self) -> io::Result<(&mut Self::Item, &mut Metadata)>;
+    fn next(&mut self) -> io::Result<(&mut Self::Item, &mut Metadata)>;
 }

--- a/src/io/userptr/stream.rs
+++ b/src/io/userptr/stream.rs
@@ -139,7 +139,7 @@ impl StreamTrait for Stream {
     }
 }
 
-impl<'a> CaptureStream<'a> for Stream {
+impl CaptureStream for Stream {
     fn queue(&mut self, index: usize) -> io::Result<()> {
         let buf = &mut self.arena.bufs[index];
         let mut v4l2_buf = v4l2_buffer {
@@ -191,7 +191,7 @@ impl<'a> CaptureStream<'a> for Stream {
         Ok(self.arena_index)
     }
 
-    fn next(&'a mut self) -> io::Result<(&Self::Item, &Metadata)> {
+    fn next(&mut self) -> io::Result<(&Self::Item, &Metadata)> {
         if !self.active {
             // Enqueue all buffers once on stream start
             for index in 0..self.arena.bufs.len() {


### PR DESCRIPTION
`mmap::Arena` has a lifetime parameter, but as far as I can tell the memory this refers to is `mmap`ed device memory managed by the `Arena` object itself. This memory is only unmapped when the `Arena` is dropped, so will remain valid for the lifetime of the `Arena` object, so I don't see any need for an external lifetime.

The `CaptureStream` and `OutputStream` traits have lifetime parameters, but they are only used by the `next` method, where the explicit lifetimes are the same as those that would have been inferred.

This PR removes all of the above lifetime parameters.